### PR TITLE
Move testing modules to test_requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -31,6 +31,8 @@ my $build = Module::Build->new
                        'File::Spec' => 0,
                        'FindBin' => 0,
                        'Module::Util' => 0,
+                     },
+   test_requires => {
                        'Test::MockTime::HiRes' => 0,
                        'Test::More' => 0,
                      },


### PR DESCRIPTION
At $work we try to keep test dependencies out of our DarkPAN. Internally we use `Courriel`, which depends on `DateTime-Format-Natural` which has `Test-MockTime` as a build requirement. Moving the test modules to the `test_requires` phase would allow us to drop `Test-MockTime` and it is also generally where I'd expect to see test-only dependencies.