### PR TITLE
Add parsing for beginning and end of  x months ago, this month, and x moths from now

### DIFF
--- a/lib/DateTime/Format/Natural/Calc.pm
+++ b/lib/DateTime/Format/Natural/Calc.pm
@@ -418,6 +418,18 @@ sub _variant_quarter
     });
 }
 
+sub _begin_end_month
+{
+    my $self = shift;
+    $self->_register_trace;
+    my $opts = pop;
+    my ($day) = @_;
+    unless (defined $day) {
+        $day = $self->_Days_in_Month($self->{datetime}->year, $self->{datetime}->month);
+    }
+    $self->_set(day => $day);
+}
+
 1;
 __END__
 

--- a/lib/DateTime/Format/Natural/Lang/EN.pm
+++ b/lib/DateTime/Format/Natural/Lang/EN.pm
@@ -5158,6 +5158,12 @@ also parsable with precision in (milli)seconds):
  last thursday in april
  beginning of last month
  end of last month
+ beginning of 3 months ago
+ end of 3 months ago
+ beginning of last month
+ end of last month
+ beginning of 3 months from now
+ end of 3 months from now
 
 =head2 Timespans
 

--- a/lib/DateTime/Format/Natural/Lang/EN.pm
+++ b/lib/DateTime/Format/Natural/Lang/EN.pm
@@ -4749,6 +4749,35 @@ $regexes{format} = qr/^$regexes{format_}(?:(?=\s)|$)/;
           { truncate_to => [q(day)] },
         ],
     ],
+    begin_end_this_month => [
+        [ 'SCALAR', 'SCALAR', 'SCALAR', 'SCALAR' ],
+        [
+          { 0 => 'beginning', 1 => 'of', 2 => 'this', 3 => 'month' },
+          [],
+          [],
+          [
+            [
+              { VALUE => 1 },
+            ],
+          ],
+          [ {} ],
+          [ '_begin_end_month' ],
+          { truncate_to => [q(day)] },
+        ],
+        [
+          { 0 => 'end', 1 => 'of', 2 => 'this', 3 => 'month' },
+          [],
+          [],
+          [
+            [
+              { VALUE => undef },
+            ],
+          ],
+          [ {} ],
+      [ '_begin_end_month' ],
+          { truncate_to => [q(day)] },
+        ],
+    ],
 );
 
 1;

--- a/lib/DateTime/Format/Natural/Lang/EN.pm
+++ b/lib/DateTime/Format/Natural/Lang/EN.pm
@@ -4718,6 +4718,37 @@ $regexes{format} = qr/^$regexes{format_}(?:(?=\s)|$)/;
          { truncate_to => [q(day)] },
        ],
     ],
+    begin_end_month_ago => [
+        [ 'SCALAR', 'SCALAR', 'REGEXP', 'REGEXP', 'SCALAR' ],
+        [
+          { 0 => 'beginning', 1 => 'of', 2 => $RE{number}, 3 => qr/^(months?)$/i, 4 => 'ago' },
+          [ [ 2, 3 ] ],
+          [ $extended_checks{suffix} ],
+          [
+            [ 2 ],
+            [
+              { VALUE => 1 },
+            ],
+          ],
+          [ { unit => 'month' }, {} ],
+          [ '_ago_variant', '_begin_end_month' ],
+          { truncate_to => [q(day)] },
+        ],
+        [
+          { 0 => 'end', 1 => 'of', 2 => $RE{number}, 3 => qr/^(months?)$/i, 4 => 'ago' },
+          [ [ 2, 3 ] ],
+          [ $extended_checks{suffix} ],
+          [
+            [ 2 ],
+            [
+              { VALUE => undef },
+            ],
+          ],
+          [ { unit => 'month' }, {} ],
+          [ '_ago_variant', '_begin_end_month' ],
+          { truncate_to => [q(day)] },
+        ],
+    ],
 );
 
 1;

--- a/lib/DateTime/Format/Natural/Lang/EN.pm
+++ b/lib/DateTime/Format/Natural/Lang/EN.pm
@@ -4778,6 +4778,43 @@ $regexes{format} = qr/^$regexes{format_}(?:(?=\s)|$)/;
           { truncate_to => [q(day)] },
         ],
     ],
+    begin_end_month_from_now => [
+        [ 'SCALAR', 'SCALAR', 'REGEXP', 'REGEXP', 'REGEXP', 'SCALAR' ],
+        [
+          { 0 => 'beginning', 1 => 'of', 2 => $RE{number}, 3 => qr/^(months?)$/i, 4 => qr/^(from)$/i, 5 => 'now' },
+          [ [ 2, 3 ] ],
+          [ $extended_checks{suffix} ],
+          [
+            [
+                2,
+                { 4 => [ $flag{before_after_from} ] },
+            ],
+            [
+              { VALUE => 1 },
+            ],
+          ],
+          [ { unit => 'month' }, {}  ],
+          [ '_now_variant', '_begin_end_month' ],
+          { truncate_to => [q(day)] },
+        ],
+        [
+          { 0 => 'end', 1 => 'of', 2 => $RE{number}, 3 => qr/^(months?)$/i, 4 => qr/^(from)$/i, 5 => 'now' },
+          [ [ 2, 3 ] ],
+          [ $extended_checks{suffix} ],
+          [
+            [
+                2,
+                { 4 => [ $flag{before_after_from} ] },
+            ],
+            [
+              { VALUE => undef },
+            ],
+          ],
+          [ { unit => 'month' }, {}  ],
+          [ '_now_variant', '_begin_end_month' ],
+          { truncate_to => [q(day)] },
+        ],
+    ],
 );
 
 1;


### PR DESCRIPTION
For now, this module can only parse "beginning of last month" and "end of last month".

This pull request adds the ability to parse "beginning of x months ago", "end of x months ago", "beginning of this month", "end of this month", "beginning of x months from now", "end of x months from now".

This can be useful when DateTime::Format::Natural is used for eg. to produce some statistics extending over x months. Some customers have asked for this in the context of Request Tracker.

Best, Gibus